### PR TITLE
Pay 6486 retry on put and post failures

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>hmcts/.github//renovate/automerge-all", "local>hmcts/.github:renovate-config"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["copy-webpack-plugin"],
+      "allowedVersions": "<=10",
+      "description": "https://canary.discord.com/channels/226791405589233664/1019534554073157642 and https://github.com/webpack-contrib/copy-webpack-plugin/issues/643 doesn't work even though issue closed"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ Run tests
 `yarn test`
 
 .
+
+Debugging tests
+
+Create a new run configuration, choosing `Node.js Mocha` from the drop down. The arguements may need changing. See below example.
+
+```
+         "args": [
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/test"
+            ],
+```

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -105,7 +105,7 @@ retryOrDeadLetter = msg => {
     } else {
         console.log(correlationId + ": Will retry message at a later time ", JSON.stringify(msg.body));
         msg.userProperties.retries++;
-        sendMessage(msg.clone());
+        sendMessage(msg.clone(), correlationId);
     }
 }
 
@@ -134,7 +134,7 @@ validateMessage = message => {
 }
 
 
-async function sendMessage(msg) {
+async function sendMessage(msg, correlationId) {
     const sBusClient = ServiceBusClient.createFromConnectionString(connectionString);
     const topicClient = sBusClient.createTopicClient(topicName);
     const topicSender = topicClient.createSender();

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -28,11 +28,11 @@ module.exports = async function serviceCallbackFunction() {
         let serviceCallbackUrl;
         let serviceName;
         let correlationId = msg.correlationId === undefined ? randomInt(100000,999999) : msg.correlationId;
-
+        msg.correlationId = correlationId;
         try {
             if (this.validateMessage(msg)) {
                 serviceCallbackUrl = msg.userProperties.serviceCallbackUrl;
-                serviceName = msg.userProperties.serviceName;
+                serviceName = msg.userProperties.serviceName === undefined ? '' : msg.userProperties.serviceName;
                 console.log(correlationId + ': Processing message from service ' + serviceName);
                 const otpPassword = otp({ secret: s2sSecret }).totp();
                 const serviceAuthRequest = {

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -103,7 +103,7 @@ retryOrDeadLetter = msg => {
                 console.log(correlationId + ": Error while dead letter messages ", err)
             });
     } else {
-        console.log(correlationId + ": Will try message at a later time ", JSON.stringify(msg.body));
+        console.log(correlationId + ": Will retry message at a later time ", JSON.stringify(msg.body));
         msg.userProperties.retries++;
         sendMessage(msg.clone());
     }

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -26,11 +26,13 @@ module.exports = async function serviceCallbackFunction() {
         let msg = messages[i];
         let serviceCallbackUrl;
         let serviceName;
-        let correlationId = msg.correlationId;
+        let correlationId = msg.correlationId === undefined ? Math.floor(100000 + Math.random() * 900000) : msg.correlationId;
         try {
             if (this.validateMessage(msg)) {
                 serviceCallbackUrl = msg.userProperties.serviceCallbackUrl;
                 serviceName = msg.userProperties.serviceName;
+
+                console.log(correlationId + ': Updated serviceCallbackFunction with fixed retries!');
 
                 const otpPassword = otp({ secret: s2sSecret }).totp();
                 const serviceAuthRequest = {
@@ -49,7 +51,7 @@ module.exports = async function serviceCallbackFunction() {
                             'Content-Type': 'application/json'
                         }
                     };
-                    console.log(correlationId + ': About to post to callback ', serviceCallbackUrl);
+                    console.log(correlationId + ': About to post callback URL ', serviceCallbackUrl);
                     axiosRequest.put(
                         serviceCallbackUrl,
                         msg.body,
@@ -72,7 +74,7 @@ module.exports = async function serviceCallbackFunction() {
                 });
             } else {
                 console.log(correlationId + ': Skipping processing invalid message and sending to dead letter' + JSON.stringify(msg.body));
-                await msg.deadLetter()
+                await msg.deadLetter();
             }
         } catch (err) {
             console.log(correlationId + ': Error response received from ', serviceCallbackUrl, err);

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -12,7 +12,7 @@ const delayTime = config.get('delayMessageMinutes');
 const s2sUrl = config.get('s2sUrl');
 const s2sSecret = config.get('secrets.ccpay.payment-s2s-secret');
 const microService = config.get('microservicePaymentApp');
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 5;
 
 module.exports = async function serviceCallbackFunction() {
     const sbClient = ServiceBusClient.createFromConnectionString(connectionString);

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -27,13 +27,12 @@ module.exports = async function serviceCallbackFunction() {
         let serviceCallbackUrl;
         let serviceName;
         let correlationId = msg.correlationId === undefined ? Math.floor(100000 + Math.random() * 900000) : msg.correlationId;
+
         try {
             if (this.validateMessage(msg)) {
                 serviceCallbackUrl = msg.userProperties.serviceCallbackUrl;
                 serviceName = msg.userProperties.serviceName;
-
-                console.log(correlationId + ': Updated serviceCallbackFunction with fixed retries!');
-
+                console.log(correlationId + ': Processing message from service ' + serviceName);
                 const otpPassword = otp({ secret: s2sSecret }).totp();
                 const serviceAuthRequest = {
                     microservice: microService,
@@ -64,13 +63,10 @@ module.exports = async function serviceCallbackFunction() {
                             console.log(correlationId + ': Error in Calling Service ' + JSON.stringify(response));
                             retryOrDeadLetter(msg);
                         }
-                    }).catch((callbackError) => {
-                        console.log(correlationId + ': Error in fetching callback request ' + callbackError);
-                        retryOrDeadLetter(msg);
                     });
                 }).catch((s2sError) => {
                     console.log(correlationId + ': Error in fetching S2S token message ' + s2sError);
-                        retryOrDeadLetter(msg);
+                    retryOrDeadLetter(msg);
                 });
             } else {
                 console.log(correlationId + ': Skipping processing invalid message and sending to dead letter' + JSON.stringify(msg.body));

--- a/serviceCallbackFunction/serviceCallbackFunction.js
+++ b/serviceCallbackFunction/serviceCallbackFunction.js
@@ -103,6 +103,7 @@ retryOrDeadLetter = msg => {
                 console.log(correlationId + ": Error while dead letter messages ", err)
             });
     } else {
+        console.log(correlationId + ": Will try message at a later time ", JSON.stringify(msg.body));
         msg.userProperties.retries++;
         sendMessage(msg.clone());
     }

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -163,6 +163,7 @@ describe("When serviceCallbackUrl returns success, s2sToken not received. 5 retr
         expect(axiosRequest.post).to.throw(error)
         expect(axiosRequest.post).callCount(6);
         expect(messages[0].userProperties.retries).to.equals(5);
+        expect(console.log).to.have.been.calledWithMatch('1234: Will try message at a later time');
         expect(messages[0].clone).to.have.been.called
     });
 });

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -163,7 +163,7 @@ describe("When serviceCallbackUrl returns success, s2sToken not received. 5 retr
         expect(axiosRequest.post).to.throw(error)
         expect(axiosRequest.post).callCount(6);
         expect(messages[0].userProperties.retries).to.equals(5);
-        expect(console.log).to.have.been.calledWithMatch('1234: Will try message at a later time');
+        expect(console.log).to.have.been.calledWithMatch('1234: Will retry message at a later time');
         expect(messages[0].clone).to.have.been.called
     });
 });

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -136,7 +136,7 @@ describe("When no userproperties recieved", function () {
     });
 });
 
-describe("When serviceCallbackUrl returns success, s2sToken not received", function () {
+describe("When serviceCallbackUrl returns success, s2sToken not received. 3 retries expected so 4 attempts in all.", function () {
     let error = new Error("S2SToken Failed");
     before(function () {
         sandbox.stub(axiosRequest, 'post').throws(error);
@@ -156,11 +156,16 @@ describe("When serviceCallbackUrl returns success, s2sToken not received", funct
 
     it('if there is an error from S2S Service Token, an error is logged', async function () {
         await serviceCallbackFunction();
+        await serviceCallbackFunction();
+        await serviceCallbackFunction();
         expect(axiosRequest.post).to.throw(error)
+        expect(axiosRequest.post).callCount(4);
+        expect(messages[0].userProperties.retries).to.equals(3);
+        expect(messages[0].clone).to.have.been.called
     });
 });
 
-describe("When serviceCallbackUrl returns success, but sending callback request fails", function () {
+describe("When serviceCallbackUrl returns success, but sending callback request fails. 3 retries expected so 4 attempts in all.", function () {
     let error = new Error("Callback Failed");
     before(function () {
         messages = [{
@@ -169,7 +174,6 @@ describe("When serviceCallbackUrl returns success, but sending callback request 
                 "amount": 3000000,
             }),
             userProperties: {
-                retries: 0,
                 serviceCallbackUrl: 'www.example.com'
             },
             complete: sandbox.stub(),
@@ -181,8 +185,12 @@ describe("When serviceCallbackUrl returns success, but sending callback request 
 
     it('if there is an error from Callback, an error is logged', async function () {
         await serviceCallbackFunction();
+        await serviceCallbackFunction();
+        await serviceCallbackFunction();
         expect(axiosRequest.put).to.throw(error);
-        expect(axiosRequest.post).to.have.been.calledOnce;
+        expect(axiosRequest.put).to.have.been.callCount(4);
+        expect(messages[0].clone).to.have.been.called
+        expect(messages[0].userProperties.retries).to.equals(3); 
     });
 });
 

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -54,11 +54,12 @@ describe("When messages are received", function () {
         expect(axiosRequest.post).to.have.been.calledOnce;
         expect(axiosRequest.put).to.have.been.calledOnce;
         expect(messages[0].complete).to.have.been.called;
-        expect(console.log).to.have.been.callCount(6);
+        expect(console.log).to.have.been.callCount(7);
+        expect(console.log).to.have.been.calledWith('1234: Updated serviceCallbackFunction with fixed retries!');
         expect(console.log).to.have.been.calledWithMatch('1234: Received callback message:');
         expect(console.log).to.have.been.calledWith('1234: Received Callback Message is Valid!!!');
         expect(console.log).to.have.been.calledWith('1234: S2S Token Retrieved.......');
-        expect(console.log).to.have.been.calledWithMatch('1234: About to post to callback');
+        expect(console.log).to.have.been.calledWithMatch('1234: About to post callback URL');
         expect(console.log).to.have.been.calledWith('1234: Response: {"amount":3000000}');
         expect(console.log).to.have.been.calledWith('1234: Message Sent Successfully to www.example.com');
     });

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -136,7 +136,7 @@ describe("When no userproperties recieved", function () {
     });
 });
 
-describe("When serviceCallbackUrl returns success, s2sToken not received. 3 retries expected so 4 attempts in all.", function () {
+describe("When serviceCallbackUrl returns success, s2sToken not received. 5 retries expected so 6 attempts in total.", function () {
     let error = new Error("S2SToken Failed");
     before(function () {
         sandbox.stub(axiosRequest, 'post').throws(error);
@@ -158,14 +158,16 @@ describe("When serviceCallbackUrl returns success, s2sToken not received. 3 retr
         await serviceCallbackFunction();
         await serviceCallbackFunction();
         await serviceCallbackFunction();
+        await serviceCallbackFunction();
+        await serviceCallbackFunction();
         expect(axiosRequest.post).to.throw(error)
-        expect(axiosRequest.post).callCount(4);
-        expect(messages[0].userProperties.retries).to.equals(3);
+        expect(axiosRequest.post).callCount(6);
+        expect(messages[0].userProperties.retries).to.equals(5);
         expect(messages[0].clone).to.have.been.called
     });
 });
 
-describe("When serviceCallbackUrl returns success, but sending callback request fails. 3 retries expected so 4 attempts in all.", function () {
+describe("When serviceCallbackUrl returns success, but sending callback request fails. 5 retries expected so 6 attempts in total.", function () {
     let error = new Error("Callback Failed");
     before(function () {
         messages = [{
@@ -187,10 +189,12 @@ describe("When serviceCallbackUrl returns success, but sending callback request 
         await serviceCallbackFunction();
         await serviceCallbackFunction();
         await serviceCallbackFunction();
+        await serviceCallbackFunction();
+        await serviceCallbackFunction();
         expect(axiosRequest.put).to.throw(error);
-        expect(axiosRequest.put).to.have.been.callCount(4);
+        expect(axiosRequest.put).callCount(6);
         expect(messages[0].clone).to.have.been.called
-        expect(messages[0].userProperties.retries).to.equals(3); 
+        expect(messages[0].userProperties.retries).to.equals(5); 
     });
 });
 

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -164,6 +164,7 @@ describe("When serviceCallbackUrl returns success, s2sToken not received. 5 retr
         expect(axiosRequest.post).callCount(6);
         expect(messages[0].userProperties.retries).to.equals(5);
         expect(console.log).to.have.been.calledWithMatch('1234: Will retry message at a later time');
+        expect(console.log).to.have.been.calledWithMatch('1234: Message is scheduled to retry at UTC:');
         expect(messages[0].clone).to.have.been.called
     });
 });
@@ -261,13 +262,15 @@ describe("When serviceCallbackUrl returns error, deadletter success", function (
         }];
     });
 
-    it('if there is an error from serviceCallbackUrl for 3 times', async function () {
+    it('if there is an error from serviceCallbackUrl for 5 times', async function () {
          await serviceCallbackFunction();
          await serviceCallbackFunction();
          await serviceCallbackFunction();
-         expect(axiosRequest.put).to.have.been.calledThrice;
+         await serviceCallbackFunction();
+         await serviceCallbackFunction();
+         expect(axiosRequest.put).to.have.been.callCount(5);
          expect(messages[0].clone).to.have.been.called
-         expect(messages[0].userProperties.retries).to.equals(3);
+         expect(messages[0].userProperties.retries).to.equals(5);
      });
 });
 
@@ -315,7 +318,7 @@ describe("When serviceCallbackUrl returns error, deadletter fails", function () 
     });
 
 
-     it('if there is an error from serviceCallbackUrl for 3 times', async function () {
+     it('if there is an error from serviceCallbackUrl for 5 times', async function () {
          await serviceCallbackFunction();
          await serviceCallbackFunction();
          await serviceCallbackFunction();

--- a/test/service-callback-function-unit.test.js
+++ b/test/service-callback-function-unit.test.js
@@ -12,7 +12,7 @@ let sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 
-let messages, loggerStub;
+let messages, loggerStub, response;
 beforeEach(function () {
     console = {
         log: sandbox.stub()
@@ -40,6 +40,7 @@ describe("When messages are received", function () {
             }),
             userProperties: {
                 retries: 0,
+                serviceName: 'Example',
                 serviceCallbackUrl: 'www.example.com'
             },
             complete: sandbox.stub(),
@@ -55,7 +56,7 @@ describe("When messages are received", function () {
         expect(axiosRequest.put).to.have.been.calledOnce;
         expect(messages[0].complete).to.have.been.called;
         expect(console.log).to.have.been.callCount(7);
-        expect(console.log).to.have.been.calledWith('1234: Updated serviceCallbackFunction with fixed retries!');
+        expect(console.log).to.have.been.calledWith('1234: Processing message from service Example');
         expect(console.log).to.have.been.calledWithMatch('1234: Received callback message:');
         expect(console.log).to.have.been.calledWith('1234: Received Callback Message is Valid!!!');
         expect(console.log).to.have.been.calledWith('1234: S2S Token Retrieved.......');


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-6486


### Change description ###
Retries on any post/put failures for getting the token and for calling the callbackUrl.
Uses the same retry logic as before, it's just moved to a new function retryOrDeadLetter.
Tests updated to reflect the new logic.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
